### PR TITLE
Fix Warsong bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/--warsong-realm-bugtracker.md
+++ b/.github/ISSUE_TEMPLATE/--warsong-realm-bugtracker.md
@@ -4,12 +4,12 @@ about: Bugs related to Warsong Realm.
 
 ---
 
-**When it occured: **
+**When it occured**
 
-**Description: **
+**Description**
 
-**How it works: **
+**How it works**
 
-**How it should work: **
+**How it should work**
 
-**Link to WoWHead/WoWWiki: **
+**Link to WoWHead/WoWWiki**


### PR DESCRIPTION
The bold markdown section headings are not rendered correctly due to the colon and space.

Removing this resolves the issue.